### PR TITLE
Fixed bug - using without conversion (original)

### DIFF
--- a/src/Fields/Image.php
+++ b/src/Fields/Image.php
@@ -84,7 +84,7 @@ class Image extends Field implements DeletableContract
      */
     protected function resolveAttribute($resource, $attribute)
     {
-        $conversion = $this->meta()['usingConversion'] ?? [];
+        $conversion = $this->meta()['usingConversion'] ?? '';
         $media = $resource->getFirstMedia($this->mediaCollection);
 
         if ($media) {


### PR DESCRIPTION
- default should be an string otherwise a exception is thrown