### PR TITLE
Make customProperties work as expected

### DIFF
--- a/resources/js/components/File/FormField.vue
+++ b/resources/js/components/File/FormField.vue
@@ -93,12 +93,6 @@
         mounted() {
             this.field.fill = formData => {
                 formData.append(this.field.attribute, this.file, this.fileName)
-
-                for (let attribute in this.field) {
-                    if (attribute.substr(0, 3) === 'ml_') {
-                        formData.append(attribute, this.field[attribute])
-                    }
-                }
             }
         },
 

--- a/resources/js/components/Image/FormField.vue
+++ b/resources/js/components/Image/FormField.vue
@@ -114,12 +114,6 @@
         mounted() {
             this.field.fill = formData => {
                 formData.append(this.field.attribute, this.file, this.fileName)
-
-                for (let attribute in this.field) {
-                    if (attribute.substr(0, 3) === 'ml_') {
-                        formData.append(attribute, this.field[attribute])
-                    }
-                }
             }
         },
 

--- a/src/Fields/File.php
+++ b/src/Fields/File.php
@@ -2,17 +2,8 @@
 
 namespace Kingsley\NovaMediaLibrary\Fields;
 
-use Illuminate\Support\Str;
-use Illuminate\Http\Request;
-use Laravel\Nova\Fields\Field;
-use Laravel\Nova\Fields\Deletable;
-use Laravel\Nova\Http\Requests\NovaRequest;
-use Laravel\Nova\Contracts\Deletable as DeletableContract;
-
-class File extends Field implements DeletableContract
+class File extends MediaField
 {
-    use Deletable;
-
     /**
      * The field's component.
      *
@@ -20,94 +11,5 @@ class File extends Field implements DeletableContract
      */
     public $component = 'nova-media-library-file-field';
 
-    /**
-     * The media collection.
-     *
-     * @var string
-     */
-    public $mediaCollection;
-
-    /**
-     * Create a new field.
-     *
-     * @return void
-     */
-    public function __construct(string $name, string $collection = 'default')
-    {
-        parent::__construct($name);
-
-        $this->mediaCollection = $collection;
-
-        $this->delete(function () {
-            //
-        });
-    }
-
-    /**
-     * Hydrate the given attribute on the model based on the incoming request.
-     *
-     * @param  \Laravel\Nova\Http\Requests\NovaRequest  $request
-     * @param  string  $requestAttribute
-     * @param  object  $model
-     * @param  string  $attribute
-     * @return void
-     */
-    protected function fillAttributeFromRequest(NovaRequest $request, $requestAttribute, $model, $attribute)
-    {
-        if (! $request[$requestAttribute]) {
-            return;
-        }
-
-        $request->validate([
-            $requestAttribute => 'file'
-        ]);
-
-        $query = $model->addMedia($request[$requestAttribute]);
-
-        foreach ($request->all() as $key => $value) {
-            if (starts_with($key, 'ml_')) {
-                $method = substr($key, 3);
-                $arguments = is_array($value) ? $value : [$value];
-                $query->$method(...$arguments);
-            }
-        }
-
-        $query->toMediaCollection($this->mediaCollection);
-    }
-
-    /**
-     * Resolve the given attribute from the given resource.
-     *
-     * @param  mixed  $resource
-     * @param  string  $attribute
-     * @return mixed
-     */
-    protected function resolveAttribute($resource, $attribute)
-    {
-        $media = $resource->getFirstMedia($this->mediaCollection);
-
-        return $media ?? null;
-    }
-
-    /**
-     * Dynamically set a media-library setting on the field.
-     *
-     * @return $this
-     */
-    public function __call($method, $arguments)
-    {
-        return $this->withMeta(['ml_' . $method => $arguments]);
-    }
-
-    /**
-     * Get additional meta information to merge with the element payload.
-     *
-     * @return array
-     */
-    public function meta()
-    {
-        return array_merge([
-            'deletable' => isset($this->deleteCallback) && $this->deletable
-        ], $this->meta);
-    }
+    protected $validationRules = ['file'];
 }

--- a/src/Fields/Image.php
+++ b/src/Fields/Image.php
@@ -85,7 +85,20 @@ class Image extends Field implements DeletableContract
     protected function resolveAttribute($resource, $attribute)
     {
         $conversion = $this->meta()['usingConversion'] ?? [];
-        $media = $resource->getFirstMedia($this->mediaCollection);
+        $customProperties = $this->meta()['ml_withCustomProperties'] ?? [];
+        $media = $resource->getMedia($this->mediaCollection);
+        
+        if (!empty($customProperties)) {
+            $customProperties = array_first($customProperties) ?: [];
+            $media = $media->first(function ($image) use ($customProperties) {
+                foreach ($customProperties as $property => $value) {
+                    $valid = ($valid ?? true) && ($image->getCustomProperty($property) == $value);
+                }
+                return $valid ?? false;
+            });
+        } else {
+            $media = $media->first();
+        }
 
         if ($media) {
             if ($media->hasGeneratedConversion($conversion)) {

--- a/src/Fields/MediaField.php
+++ b/src/Fields/MediaField.php
@@ -86,7 +86,7 @@ abstract class MediaField extends Field implements DeletableContract
      */
     protected function resolveAttribute($resource, $attribute)
     {
-        $customProperties = $this->mediaLibraryMethods['withCustomProperties'] ?? [];
+        $customProperties = $this->mediaLibraryMethods['withCustomProperties'] ?? '';
         $media = $resource->getMedia($this->mediaCollection);
 
         if (!empty($customProperties)) {

--- a/src/Fields/MediaField.php
+++ b/src/Fields/MediaField.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace Kingsley\NovaMediaLibrary\Fields;
+
+use Laravel\Nova\Fields\Field;
+use Laravel\Nova\Fields\Deletable;
+use Laravel\Nova\Http\Requests\NovaRequest;
+use Laravel\Nova\Contracts\Deletable as DeletableContract;
+
+abstract class MediaField extends Field implements DeletableContract
+{
+    use Deletable;
+
+    /**
+     * The media collection.
+     *
+     * @var string
+     */
+    public $mediaCollection;
+
+    /**
+     * The media collection methods
+     * to apply to this field.
+     *
+     * @var array
+     */
+    protected $mediaLibraryMethods = [];
+
+    /**
+     * The validation rules.
+     *
+     * @var array
+     */
+    protected $validationRules = [];
+
+    /**
+     * Create a new field.
+     *
+     * @return void
+     */
+    public function __construct(string $name, string $collection = 'default')
+    {
+        parent::__construct($name);
+
+        $this->mediaCollection = $collection;
+
+        $this->delete(function () {
+            //
+        });
+    }
+
+    /**
+     * Hydrate the given attribute on the model based on the incoming request.
+     *
+     * @param  \Laravel\Nova\Http\Requests\NovaRequest  $request
+     * @param  string  $requestAttribute
+     * @param  object  $model
+     * @param  string  $attribute
+     * @return void
+     */
+    protected function fillAttributeFromRequest(NovaRequest $request, $requestAttribute, $model, $attribute)
+    {
+        if (! $request[$requestAttribute]) {
+            return;
+        }
+
+        $request->validate([
+            $requestAttribute => $this->validationRules
+        ]);
+
+        $query = $model->addMedia($request[$requestAttribute]);
+
+        foreach ($this->mediaLibraryMethods as $method => $arguments) {
+            $query->$method(...$arguments);
+        }
+
+        $query->toMediaCollection($this->mediaCollection);
+    }
+
+    /**
+     * Resolve the given attribute from the given resource.
+     *
+     * @param  mixed  $resource
+     * @param  string  $attribute
+     * @return mixed
+     */
+    protected function resolveAttribute($resource, $attribute)
+    {
+        $customProperties = $this->mediaLibraryMethods['withCustomProperties'] ?? [];
+        $media = $resource->getMedia($this->mediaCollection);
+
+        if (!empty($customProperties)) {
+            $customProperties = array_first($customProperties) ?: [];
+            $media = $media->first(function ($item) use ($customProperties) {
+                foreach ($customProperties as $property => $value) {
+                    $valid = ($valid ?? true) && $item->getCustomProperty($property) == $value;
+                }
+                return $valid ?? false;
+            });
+        } else {
+            $media = $media->first();
+        }
+
+        return $media ?? null;
+    }
+
+    /**
+     * Dynamically set a media-library setting on the field.
+     *
+     * @return $this
+     */
+    public function __call($method, $arguments)
+    {
+        $this->mediaLibraryMethods[$method] = $arguments;
+
+        return $this;
+    }
+
+    /**
+     * Get additional meta information to merge with the element payload.
+     *
+     * @return array
+     */
+    public function meta()
+    {
+        return array_merge([
+            'deletable' => isset($this->deleteCallback) && $this->deletable
+        ], $this->meta);
+    }
+}


### PR DESCRIPTION
I know you had said that this package will be left as is but I was hoping that wouldn't include PR's....

When using customProperties as it stands now, the expected results would be that the image shown would be the image with the customProperties only. That is not the case and although you can set the image and the customProperties are added, they aren't respected when looking up the image for detail or Form views.

This just handles that particular case so that customProperties are expected.